### PR TITLE
brdinheiro - Atualização/recuperação do valor de atributo usado como dinheiro

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ env = %(PKG_BUILD="#{ENV["PKG_BUILD"]}") if ENV["PKG_BUILD"]
 PROJECTS_WITH_TEST_UNIT = %w(brnumeros brdinheiro brcep brdata brhelper brstring brI18n)
 PROJECTS_WITH_RSPEC = %w(brcpfcnpj)
 PROJECTS = PROJECTS_WITH_TEST_UNIT + PROJECTS_WITH_RSPEC
-PKG_VERSION = "3.0.4"
+PKG_VERSION = "3.0.5"
 
 Dir["#{File.dirname(__FILE__)}/*/lib/*/version.rb"].each do |version_path|
   require version_path

--- a/brI18n/lib/brI18n/version.rb
+++ b/brI18n/lib/brI18n/version.rb
@@ -2,7 +2,7 @@ module BrI18n
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brcep/lib/brcep/version.rb
+++ b/brcep/lib/brcep/version.rb
@@ -2,7 +2,7 @@ module BrCep
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brcpfcnpj/lib/brcpfcnpj/version.rb
+++ b/brcpfcnpj/lib/brcpfcnpj/version.rb
@@ -2,7 +2,7 @@ module BrCpfCnpj
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brdata/lib/brdata/version.rb
+++ b/brdata/lib/brdata/version.rb
@@ -2,7 +2,7 @@ module BrData
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brdinheiro/lib/brdinheiro/dinheiro_active_record.rb
+++ b/brdinheiro/lib/brdinheiro/dinheiro_active_record.rb
@@ -33,6 +33,10 @@ module DinheiroActiveRecord#:nodoc:
               end
             end
           end
+          
+          def #{name}
+            read_attribute(:#{name})
+          end
           ADICIONANDO_METODO
         end
       end

--- a/brdinheiro/lib/brdinheiro/version.rb
+++ b/brdinheiro/lib/brdinheiro/version.rb
@@ -2,7 +2,7 @@ module BrDinheiro
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brdinheiro/test/active_record/base_without_table.rb
+++ b/brdinheiro/test/active_record/base_without_table.rb
@@ -11,7 +11,11 @@ module ActiveRecord
     def save
       self.valid?
     end
-
+    
+    def column_for_attribute(name)
+      self.class.columns_hash[name.to_s]
+    end
+    
     class << self
       def columns()
         @columns ||= []
@@ -27,7 +31,29 @@ module ActiveRecord
         undefine_attribute_methods
         @column_names = @columns_hash = @content_columns = @dynamic_methods_hash = @read_methods = nil
       end
+      
+      def columns_hash
+        hash = {}
+        columns.each do |column|
+          hash[column.name] = column
+        end
+        hash
+      end
+      
+      def column_defaults
+        defaults = {}
+        columns.each do |column|
+          defaults[column.name.to_sym] = nil
+        end
+        defaults
+      end
     end
+    
+    private
+      def self.attributes_protected_by_default
+        []
+      end
+    
   end
 end
 

--- a/brdinheiro/test/dinheiro_active_record_test.rb
+++ b/brdinheiro/test/dinheiro_active_record_test.rb
@@ -44,6 +44,12 @@ class DinheiroActiveRecordTest < Test::Unit::TestCase
     carteira = Carteira.new(:saldo => "1")
     assert_equal 1.real, carteira.saldo
   end
+  
+  def test_se_atualiza_valor_inicializado
+    carteira = Carteira.new(:saldo => 10.reais)
+    carteira.saldo += 5.reais
+    assert_equal 15.reais, carteira.saldo
+  end
 
 end
 

--- a/brhelper/lib/brhelper/version.rb
+++ b/brhelper/lib/brhelper/version.rb
@@ -2,7 +2,7 @@ module BrHelper
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brnumeros/lib/brnumeros/version.rb
+++ b/brnumeros/lib/brnumeros/version.rb
@@ -2,7 +2,7 @@ module BrNumeros
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end

--- a/brstring/lib/brstring/version.rb
+++ b/brstring/lib/brstring/version.rb
@@ -2,7 +2,7 @@ module BrString
   module VERSION #:nodoc:
     MAJOR = 3
     MINOR = 0
-    TINY = 4
+    TINY = 5
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end


### PR DESCRIPTION
Encontrei um problema no brDinheiro que não permite a recuperação de atributo de um objeto ActiveRecord que está sendo usado como dinheiro, quando este atributo é inicializado pelo construtor da classe. Acho que é mais fácil de entender em uma sessão do console. Estou usando o seguinte _model_:

``` ruby
class Grana < ActiveRecord::Base
  usar_como_dinheiro :valor
end
```

No console:

```
1.9.3-p0 :001 > g = Grana.new({ :valor => 10.reais })
 => #<Grana id: nil, valor: #<BigDecimal:7fe735469b90,'0.1E2',9(18)>, created_at: nil, updated_at: nil> 
1.9.3-p0 :002 > g.valor
 => 10,00 
1.9.3-p0 :003 > g.valor = 15.reais
 => 15,00 
1.9.3-p0 :004 > g.valor
 => 10,00 

```

Vejam que ao atribuir um novo valor, não é possível recuperar depois este novo valor.

Simulei o problema da seguinte forma:

Usando **Rails 3.1.3** e **Ruby 1.9.3**
1. Criei um projeto novo do rails: 
   `rails new teste -T`
2. Incluí o brazilian-rails no meu Gemfile:
   `gem 'brazilian-rails'`
3. Rodei o bundle: `bundle install`
4. Criei um modelo simples: `rails g model Grana valor:decimal`
5. Rodei a migration: `rake db:migrate`
6. Incluí a linha `usar_como_dinheiro :valor` no model, que ficou igual ao que eu coloquei acima.
7. Acessei o console (`rails c`) e simulei conforme a sessão do console acima.

Anexei uma sugestão de correção nesta issue, caso queiram aproveitá-la :-)
