### PR TITLE
Valida atributo como CPF ou CNPJ

### DIFF
--- a/brcpfcnpj/lib/brcpfcnpj.rb
+++ b/brcpfcnpj/lib/brcpfcnpj.rb
@@ -2,7 +2,7 @@
 $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
-%w(cpf_cnpj cnpj cpf cpf_cnpj_activerecord cnpj_validator cpf_validator).each {|req| require File.dirname(__FILE__) + "/brcpfcnpj/#{req}"}
+%w(cpf_cnpj cnpj cpf cpf_ou_cnpj cpf_cnpj_activerecord cnpj_validator cpf_validator cpf_ou_cnpj_validator).each {|req| require File.dirname(__FILE__) + "/brcpfcnpj/#{req}"}
 
 %w(rubygems active_record active_support).each {|req| require req }
 

--- a/brcpfcnpj/lib/brcpfcnpj/cpf_cnpj.rb
+++ b/brcpfcnpj/lib/brcpfcnpj/cpf_cnpj.rb
@@ -4,7 +4,14 @@ module CpfCnpj
 
   def initialize(numero)
     @numero = numero
-    @match = self.instance_of?(Cpf) ? @numero =~ CPF_REGEX : @numero =~ CNPJ_REGEX
+    @limpo = @numero.gsub(/[\.\/-]/, "")
+    if self.instance_of?(Cpf)
+      @match = @numero =~ CPF_REGEX
+    elsif self.instance_of?(Cnpj)
+      @match = @numero =~ CNPJ_REGEX
+    else
+      @match = @numero =~ CPF_REGEX || @numero =~ CNPJ_REGEX
+    end
     @numero_puro = $1
     @para_verificacao = $2
     @numero = (@match ? format_number! : nil)
@@ -41,13 +48,14 @@ module CpfCnpj
 
 
   def verifica_numero
-    limpo = @numero.gsub(/[\.\/-]/, "")
     if self.instance_of? Cpf
-      return false if limpo.length != 11
+      return false if @limpo.length != 11
     elsif self.instance_of? Cnpj
-      return false if limpo.length != 14
+      return false if @limpo.length != 14
+    elsif self.instance_of? CpfOuCnpj
+      return false if @limpo.length != 11 && @limpo.length != 14
     end
-    return false if limpo.scan(/\d/).uniq.length == 1
+    return false if @limpo.scan(/\d/).uniq.length == 1
     primeiro_verificador = primeiro_digito_verificador
     segundo_verificador = segundo_digito_verificador(primeiro_verificador)
     verif = primeiro_verificador + segundo_verificador
@@ -65,19 +73,19 @@ module CpfCnpj
   end
 
   def primeiro_digito_verificador
-    array = self.instance_of?(Cpf) ? CPF_ALGS_1 : CNPJ_ALGS_1
+    array = @limpo.length == 11 ? CPF_ALGS_1 : CNPJ_ALGS_1
     soma = multiplica_e_soma(array, @numero_puro)
     digito_verificador(soma%DIVISOR).to_s
   end
 
   def segundo_digito_verificador(primeiro_verificador)
-    array = self.instance_of?(Cpf) ? CPF_ALGS_2 : CNPJ_ALGS_2
+    array = @limpo.length == 11 ? CPF_ALGS_2 : CNPJ_ALGS_2
     soma = multiplica_e_soma(array, @numero_puro + primeiro_verificador)
     digito_verificador(soma%DIVISOR).to_s
   end
 
   def format_number!
-    if self.instance_of? Cpf
+    if @limpo.length == 11
       @numero =~ /(\d{3})\.?(\d{3})\.?(\d{3})-?(\d{2})/
       @numero = "#{$1}.#{$2}.#{$3}-#{$4}"
     else

--- a/brcpfcnpj/lib/brcpfcnpj/cpf_cnpj_activerecord.rb
+++ b/brcpfcnpj/lib/brcpfcnpj/cpf_cnpj_activerecord.rb
@@ -11,6 +11,10 @@ module CpfCnpjActiveRecord #:nodoc:
     def usar_como_cnpj(*args) #:nodoc:
       init(args, 'Cnpj')
     end
+    
+    def usar_como_cpf_ou_cnpj(*args) #:nodoc:
+      init(args, 'CpfOuCnpj')
+    end
 
     def init(args, klass)
       unless args.size.zero?

--- a/brcpfcnpj/lib/brcpfcnpj/cpf_ou_cnpj.rb
+++ b/brcpfcnpj/lib/brcpfcnpj/cpf_ou_cnpj.rb
@@ -1,0 +1,3 @@
+class CpfOuCnpj
+  include CpfCnpj
+end

--- a/brcpfcnpj/lib/brcpfcnpj/cpf_ou_cnpj_validator.rb
+++ b/brcpfcnpj/lib/brcpfcnpj/cpf_ou_cnpj_validator.rb
@@ -1,0 +1,6 @@
+class CpfOuCnpjValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+    record.errors.add attribute, :invalid unless CpfOuCnpj.new(value).valido?
+  end
+end

--- a/brcpfcnpj/spec/cpf_ou_cnpj_active_record_spec.rb
+++ b/brcpfcnpj/spec/cpf_ou_cnpj_active_record_spec.rb
@@ -1,0 +1,139 @@
+# -*- encoding : utf-8 -*-
+require File.dirname(__FILE__) + '/spec_helper'
+require File.dirname(__FILE__) + '/active_record/base_without_table'
+
+class Cliente < ActiveRecord::Base
+  usar_como_cpf_ou_cnpj :codigo
+end
+
+describe "Using a model attribute as CpfOuCnpj" do
+
+  before(:each) do
+    @cliente = Cliente.new(:nome => "Fulano")
+  end
+
+  it "should format the received Cpf" do
+    @cliente.codigo = "11144477735"
+    @cliente.codigo.numero.should == "111.444.777-35"
+  end
+
+  it "should format the received Cnpj" do
+    @cliente.codigo = "69103604000160"
+    @cliente.codigo.numero.should == "69.103.604/0001-60"
+  end
+
+  it "should respond to codigo_valido?" do
+    @cliente.respond_to?('codigo_valido?').should be_true
+  end
+
+  it "should be invalid with an invalid CpfOuCnpj number" do
+    @cliente.codigo = "123545"
+    @cliente.should_not be_valid
+  end
+
+  it "should be invalid with a too long number" do
+    @cliente.codigo = "123456678654454"
+    @cliente.should_not be_valid
+  end
+
+  it "should be valid with an empty string in the constructor of an instance of CpfOuCnpj" do
+    @cliente.codigo = CpfOuCnpj.new("")
+    @cliente.should be_valid
+  end
+
+  it "should be valid with an empty string as the codigo number" do
+    @cliente.codigo = ""
+    @cliente.should be_valid
+  end
+
+  it "should not save the instance with an invalid codigo" do
+    @cliente.codigo = "sdwewe"
+    @cliente.save.should be_false
+  end
+
+  it "should have an error in the codigo field when invalid" do
+    @cliente.codigo = "232df"
+    @cliente.save.should be_false
+    @cliente.errors[:codigo].should == ["is invalid"]
+  end
+
+  it "should be valid with a null codigo number" do
+    @cliente.codigo = nil
+    @cliente.should be_valid
+  end
+
+  it "should accept an instance of CpfCnpj (cpf)" do
+    @cliente.codigo = CpfOuCnpj.new("11144477735")
+    @cliente.codigo.should be_instance_of(CpfOuCnpj)
+  end
+
+  it "should accept an instance of CpfCnpj (cnpj)" do
+    @cliente.codigo = CpfOuCnpj.new("69103604000160")
+    @cliente.codigo.should be_instance_of(CpfOuCnpj)
+  end
+
+  it "should be able to receive parameters at initialization (cpf)" do
+    @cliente = Cliente.new(:codigo => "111.44477735")
+    @cliente.codigo.numero.should == "111.444.777-35"
+  end
+
+  it "should be able to receive parameters at initialization (cnpj)" do
+    @cliente = Cliente.new(:codigo => "69.103604000160")
+    @cliente.codigo.numero.should == "69.103.604/0001-60"
+  end
+
+  it "should change the current attribute's value" do
+    @cliente.codigo = CpfOuCnpj.new("13434")
+    lambda {
+      @cliente.codigo = CpfOuCnpj.new("111.444.777-35")
+    }.should change(@cliente, :codigo)
+  end
+end
+
+describe "when validating" do
+  describe "presence" do
+    before do
+      Cliente.validates_presence_of :codigo
+    end
+
+    it "should be invalid with a nil codigo number" do
+      c = Cliente.new(:nome => "Fulano", :codigo => nil)
+      c.should_not be_valid
+      c.errors[:codigo].should eql(["can't be blank"])
+    end
+
+    it "should be invalid with an empty string as the codigo number" do
+      c = Cliente.new(:nome => "Fulano", :codigo => "")
+      c.should_not be_valid
+      c.errors[:codigo].should_not be_empty
+    end
+
+    it "should be valid with a codigo (cpf)" do
+      Cliente.new(:nome => "Fulano", :codigo => "11144477735").should be_valid
+    end
+
+    it "should be valid with a codigo (cnpj)" do
+      Cliente.new(:nome => "Fulano", :codigo => "69103604000160").should be_valid
+    end
+  end
+
+  describe "uniqueness" do
+    before(:each) do
+      Cliente.validates_uniqueness_of :codigo
+      @c1 = Cliente.new(:nome => "Beltrano", :codigo => "11144477735")
+      @c1.save
+    end
+
+    it "should validate uniqueness of codigo" do
+      c2 = Cliente.new(:nome => "Beltrano", :codigo => "11144477735")
+      c2.should_not be_valid
+      c2.errors[:codigo].should_not be_empty
+    end
+
+    it "should be valid using a new cpf" do
+      c2 = Cliente.new(:nome => "Fulano", :codigo => "00123456797")
+      c2.should be_valid
+    end
+  end
+end
+

--- a/brcpfcnpj/spec/cpf_ou_cnpj_spec.rb
+++ b/brcpfcnpj/spec/cpf_ou_cnpj_spec.rb
@@ -1,0 +1,95 @@
+# -*- encoding : utf-8 -*-
+require File.dirname(__FILE__) + '/spec_helper'
+
+describe CpfOuCnpj do
+
+  it "should be invalid with malformed cnpj number" do
+    numeros = %w(04.22A.284/0001-11 04.222-284.0001-11 04222/284/0001-11)
+    numeros.each do |n|
+      cliente = CpfOuCnpj.new(n)
+      cliente.should_not be_valido
+    end
+  end
+  
+  it "should be invalid with malformed cpf number" do
+    numeros = %w(345.65.67.3 567.765-87698 345456-654-01 123456)
+    numeros.each do |n|
+      cliente = CpfOuCnpj.new(n)
+      cliente.should_not be_valido
+    end
+  end  
+
+  it "should be invalid with invalid cnpj number" do
+    numeros = %w(69103604020160 00000000000000 69.103.604/0001-61 01618211000264)
+    numeros.each do |n|
+      cliente = CpfOuCnpj.new(n)
+      cliente.should_not be_valido
+    end
+  end
+
+  it "should be invalid with invalid cpf number" do
+    numeros = %w(23342345699 34.543.567-98 456.676456-87 333333333-33 00000000000 000.000.000-00)
+    numeros.each do |n|
+      cliente = CpfOuCnpj.new(n)
+      cliente.should_not be_valido
+    end
+  end  
+
+  it "should be invalid with a number longer than 14 chars, even if the first 14 represent a valid number" do
+    %w(691036040001-601 69103604000160a 69103604000160ABC 6910360400016000).each do |n|
+      CpfOuCnpj.new(n).should_not be_valido
+    end
+  end
+  
+  it "should be invalid with a number longer than 11 chars, even if the first 11 char represent a valid cpf number" do
+    %w(111.444.777-3500 11144477735AB).each do |n|
+      CpfOuCnpj.new(n).should_not be_valido
+    end
+  end  
+
+  it "should be valid with correct cnpj number" do
+    numeros = %w(69103604000160 69.103.604/0001-60 01518211/000264 01.5182110002-64 00.000.000/1447-89)
+    numeros.each do |n|
+      cnpj = CpfOuCnpj.new(n)
+      cnpj.should be_valido
+    end
+  end
+  
+  it "should be valid with correct cpf number" do
+    numeros = %w(111.444.777-35 11144477735 111.444777-35 111444.777-35 111.444.77735)
+    numeros.each do |n|
+      cpf = CpfOuCnpj.new(n)
+      cpf.should be_valido
+    end
+  end  
+
+  it "should return the formated cnpj" do
+    cnpj = CpfOuCnpj.new("69103604000160")
+    cnpj.to_s.should == "69.103.604/0001-60"
+  end
+
+  it "should format the received number at instantiation" do
+    cnpj = CpfOuCnpj.new("69103604000160")
+    cnpj.numero.should == "69.103.604/0001-60"
+  end
+
+  it "should be equal to another instance with the same number" do
+    CpfOuCnpj.new("69103604000160").should == CpfOuCnpj.new("69.103.604/0001-60")
+  end
+
+  it "should return the formated cpf" do
+    cpf = CpfOuCnpj.new("11144477735")
+    cpf.to_s.should == "111.444.777-35"
+  end
+
+  it "should format the received number at instantiation" do
+    cpf = CpfOuCnpj.new("11144477735")
+    cpf.numero.should == "111.444.777-35"
+  end
+
+  it "should be equal to another instance with the same number" do
+    CpfOuCnpj.new("11144477735").should == CpfOuCnpj.new("111.444.777-35")
+  end  
+end
+
+

--- a/brcpfcnpj/spec/cpf_ou_cnpj_validator_spec.rb
+++ b/brcpfcnpj/spec/cpf_ou_cnpj_validator_spec.rb
@@ -1,0 +1,26 @@
+require File.dirname(__FILE__) + '/spec_helper'
+require File.dirname(__FILE__) + '/active_record/base_without_table'
+
+class Customer < ActiveRecord::Base
+  validates :codigo, :cpf_ou_cnpj => true
+end
+
+describe CpfOuCnpjValidator do
+  it "should isn't valid when the codigo isn't valid" do
+    @customer = Customer.new(:codigo => "12345")
+    @customer.valid?.should be_false
+    @customer.errors[:codigo].should == ["is invalid"]
+  end
+  it "should accept a nil codigo" do
+    @customer = Customer.new(:codigo => nil)    
+    @customer.valid?.should be_true
+  end
+  it "should be valid with a valid cnpj" do
+    @customer = Customer.new(:codigo => "69103604000160")
+    @customer.valid?.should be_true
+  end
+  it "should be valid with a valid cpf" do
+    @customer = Customer.new(:codigo => "11144477735")
+    @customer.valid?.should be_true
+  end
+end

--- a/brcpfcnpj/spec/db/create_testing_structure.rb
+++ b/brcpfcnpj/spec/db/create_testing_structure.rb
@@ -17,6 +17,14 @@ class CreateTestingStructure < ActiveRecord::Migration
       t.string :nome
       t.string :cpf
     end
+    create_table :clientes do |t|
+      t.string :nome
+      t.string :codigo
+    end
+    create_table :customers do |t|
+      t.string :nome
+      t.string :codigo
+    end
   end
 
   def self.down
@@ -24,6 +32,8 @@ class CreateTestingStructure < ActiveRecord::Migration
     drop_table :empresas
     drop_table :companies
     drop_table :people
+    drop_table :clientes
+    drop_table :customers
   end
 end
 


### PR DESCRIPTION
Olá pessoal,

Essa implementação surgiu da necessidade que tive em um projeto de utilizar um atributo hora como cnpj hora como cpf (o cliente poderia ser pessoa física ou jurídica).

Ao usar "usar_como_cpf_ou_cnpj" é possível validar se o valor do atributo é cpf ou cnpj.

``` ruby
class Cliente < ActiveRecord::Base
  usar_como_cpf_ou_cnpj :codigo
end

# válido (cpf)
Cliente.new(:codigo => "11144477735")

# válido (cnpj)
Cliente.new(:codigo => "69103604000160")

# inválido
Cliente.new(:codigo => "123456789")

```

Esta é minha contribuição caso considerem útil adicionar ao projeto.

Abs.
