### PR TITLE
Ajuste na expressão regular usada em String#remover_acentos

### DIFF
--- a/brstring/lib/brstring/string_portuguese.rb
+++ b/brstring/lib/brstring/string_portuguese.rb
@@ -39,7 +39,7 @@ class String
   #  String.remover_acentos('texto está com acentuação') ==> 'texto esta com acentuacao'
   def self.remover_acentos(texto)
     return texto if texto.blank?
-    texto = texto.gsub(/[á|à|ã|â|ä]/, 'a').gsub(/(é|è|ê|ë)/, 'e').gsub(/(í|ì|î|ï)/, 'i').gsub(/(ó|ò|õ|ô|ö)/, 'o').gsub(/(ú|ù|û|ü)/, 'u')
+    texto = texto.gsub(/(á|à|ã|â|ä)/, 'a').gsub(/(é|è|ê|ë)/, 'e').gsub(/(í|ì|î|ï)/, 'i').gsub(/(ó|ò|õ|ô|ö)/, 'o').gsub(/(ú|ù|û|ü)/, 'u')
     texto = texto.gsub(/(Á|À|Ã|Â|Ä)/, 'A').gsub(/(É|È|Ê|Ë)/, 'E').gsub(/(Í|Ì|Î|Ï)/, 'I').gsub(/(Ó|Ò|Õ|Ô|Ö)/, 'O').gsub(/(Ú|Ù|Û|Ü)/, 'U')
     texto = texto.gsub(/ñ/, 'n').gsub(/Ñ/, 'N')
     texto = texto.gsub(/ç/, 'c').gsub(/Ç/, 'C')

--- a/brstring/test/string_portuguese_test.rb
+++ b/brstring/test/string_portuguese_test.rb
@@ -104,6 +104,17 @@ class StringPortugueseTest < Test::Unit::TestCase
     assert_equal 'aeiouAEIOU', string
   end
 
+  def test_nao_trocar_caracter_pipe_pelo_caracter_a_ao_removere_acentos
+    assert_equal '|', String.remover_acentos('|')
+    assert_not_equal 'a', String.remover_acentos('|')
+    assert_equal '|', '|'.remover_acentos
+    assert_not_equal 'a', '|'.remover_acentos
+    char_pipe = '|'
+    char_pipe.remover_acentos!
+    assert_equal '|', char_pipe
+    assert_not_equal 'a', char_pipe
+  end
+
   def test_string_downcase
     assert_equal String::MINUSCULAS, String.downcase(String::MAIUSCULAS)
     assert_nil String.downcase(nil)


### PR DESCRIPTION
Hoje, ao usar os métodos para remover acentos de strings, o "|" é substituído por "a".
