### PR TITLE
Conversão para JSON

### DIFF
--- a/brdinheiro/lib/brdinheiro/dinheiro.rb
+++ b/brdinheiro/lib/brdinheiro/dinheiro.rb
@@ -14,6 +14,16 @@ class Dinheiro
     self.quantia = quantia
   end
 
+  # Retorna o valor em Float quando uma coleção 
+  # ou objeto é convertido para JSON
+  # 
+  # Exemplo:
+  #  produto = Produto.find 1
+  #  produto.to_json // {"nome": "MacBook", "valor": 3500.0}
+  def as_json
+    self.to_f
+  end
+
   # Retorna o valor armazenado em string.
   #
   # Exemplo:


### PR DESCRIPTION
Quando convertia um objeto ou coleção para JSON, no lugar do valor, era criado mais uma seção chamada "quantia", e o valor era exibido sem formatação.

Exemplo:
    Antes:
        produto.to_json  // {"nome": "MacBoock", "valor": {"quantia": 350000}}
       Depois:
                produto.to_json //{"nome": "MacBook", "valor": 3500.0}
