### PR TITLE
Remoção de atribuição desnecessária a constante FERIADOS_PATH

### DIFF
--- a/brdata/lib/brdata.rb
+++ b/brdata/lib/brdata.rb
@@ -33,7 +33,6 @@ $VERBOSE = old_verbose
 feriados, metodos = FeriadoParser.parser(File.dirname(__FILE__) + "/brdata/config")
 
 # Verifica se existe arquivo de feriados na aplicação e carrega-os
-FERIADOS_PATH = ""
 FERIADOS_PATH = File.expand_path(File.split(APP_PATH)[0] + "/feriados",  __FILE__) if defined?(APP_PATH)
 if File.directory?(FERIADOS_PATH)
   f, m = FeriadoParser.parser(FERIADOS_PATH)


### PR DESCRIPTION
Ao iniciar o servidor de uma aplicação que utiliza a biblioteca brdata sempre aparecia a mensagem de alerta:

/.rvm/gems/ruby-1.9.3-p194/gems/brdata-3.3.0/lib/brdata.rb:37: warning: already initialized constant FERIADOS_PATH

A constante recebia duas atribuições.
