### PR TITLE
Ao inicializar o servidor gerava erro de redefinição de constante

### DIFF
--- a/brdata/lib/brdata.rb
+++ b/brdata/lib/brdata.rb
@@ -33,9 +33,8 @@ $VERBOSE = old_verbose
 feriados, metodos = FeriadoParser.parser(File.dirname(__FILE__) + "/brdata/config")
 
 # Verifica se existe arquivo de feriados na aplicação e carrega-os
-FERIADOS_PATH = ""
 FERIADOS_PATH = File.expand_path(File.split(APP_PATH)[0] + "/feriados",  __FILE__) if defined?(APP_PATH)
-if File.directory?(FERIADOS_PATH)
+if defined?(FERIADOS_PATH) && File.directory?(FERIADOS_PATH)
   f, m = FeriadoParser.parser(FERIADOS_PATH)
   feriados += f
   metodos += m

--- a/brdata/test/warnings_test.rb
+++ b/brdata/test/warnings_test.rb
@@ -1,0 +1,21 @@
+require 'test/unit'
+require 'stringio'
+
+class WarningsTest < Test::Unit::TestCase
+  def setup
+    @old_stderr = $stderr
+    $stderr = StringIO.new
+  end
+
+  def teardown
+    $stderr = @old_stderr
+  end
+
+  def test_to_show_warnings_if_app_path_is_defined
+    Object.const_set(:APP_PATH, 'true')
+    require File.dirname(__FILE__) + '/../lib/brdata.rb'
+
+    warnings = $stderr.string.split(/\n/)
+    warnings.each { |w| assert_no_match(/warning: already initialized constant/, w) }
+  end
+end


### PR DESCRIPTION
Ao inicializar o servidor via `rails s` gerava um warning por sobrescrever a constante _FERIADOS_PATH_. Desta forma adicionei um teste para evidenciar o problema e uma possível correção.

A seguir o warning comentado:

```
/home/waldyr/.rvm/gems/ruby-1.9.2-p320/gems/brdata-3.3.0/lib/brdata.rb:37: warning: already initialized constant FERIADOS_PATH
```
