### PR TITLE
Removendo erro "warning already initialized constant FERIADOS_PATH"

### DIFF
--- a/brdata/lib/brdata.rb
+++ b/brdata/lib/brdata.rb
@@ -33,8 +33,7 @@ $VERBOSE = old_verbose
 feriados, metodos = FeriadoParser.parser(File.dirname(__FILE__) + "/brdata/config")
 
 # Verifica se existe arquivo de feriados na aplicação e carrega-os
-FERIADOS_PATH = ""
-FERIADOS_PATH = File.expand_path(File.split(APP_PATH)[0] + "/feriados",  __FILE__) if defined?(APP_PATH)
+FERIADOS_PATH = (File.expand_path(File.split(APP_PATH)[0] + "/feriados",  __FILE__) if defined?(APP_PATH)) || ""
 if File.directory?(FERIADOS_PATH)
   f, m = FeriadoParser.parser(FERIADOS_PATH)
   feriados += f


### PR DESCRIPTION
Removendo erro "warning already initialized constant FERIADOS_PATH"
Atribuir string vazia apenas se não existir o arquivo de feriados na aplicação.
