### PR TITLE
Avoid setting a constant twice

### DIFF
--- a/brdata/lib/brdata.rb
+++ b/brdata/lib/brdata.rb
@@ -33,8 +33,8 @@ $VERBOSE = old_verbose
 feriados, metodos = FeriadoParser.parser(File.dirname(__FILE__) + "/brdata/config")
 
 # Verifica se existe arquivo de feriados na aplicação e carrega-os
-FERIADOS_PATH = ""
-FERIADOS_PATH = File.expand_path(File.split(APP_PATH)[0] + "/feriados",  __FILE__) if defined?(APP_PATH)
+
+FERIADOS_PATH = defined?(APP_PATH) ? File.expand_path(File.split(APP_PATH)[0] + "/feriados",  __FILE__) : ""
 if File.directory?(FERIADOS_PATH)
   f, m = FeriadoParser.parser(FERIADOS_PATH)
   feriados += f


### PR DESCRIPTION
Fixes warnings like:
... /gems/brdata-3.3.0/lib/brdata.rb:37: warning: already initialized constant FERIADOS_PATH
... /gems/brdata-3.3.0/lib/brdata.rb:36: warning: previous definition of FERIADOS_PATH was here
