### PR TITLE
Remove link inválido para API

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -50,10 +50,6 @@ Por padrão a gem não carrega o suporte de traduções do Rails, para usa-la vo
 
 	require 'brI18n'
 
-## Como funciona?
-
-Está tudo explicado na nossa [api][].
-
 ## Achei um BUG, o que eu faço?
 
 No melhor seria fazer um fork, adicionar os testes para reproduzir o erro, implementar a devida correção e fazer um pull request. Se acha que não tem capacidade para isso (tá com preguiça), por favor, nos avise! Isso é fácil e rápido. Isso pode ser feito em <http://github.com/tapajos/brazilian-rails/issues>
@@ -120,7 +116,6 @@ As duvidas podem ser enviadas diretamente a um dos desenvolvedores ou através d
 [![Improve It][logo]][ii]
 
 [rf]: http://rubyforge.org/projects/brazilian-rails/
-[api]: http://brazilian-rails.improveit.com.br/software_livre/brazilian_rails
 [ii]: http://www.improveit.com.br
 [logo]: http://www.improveit.com.br/images/logo/logo_improve_it_screen.gif "Improve It"
 [tino]: http://tinogomes.wordpress.com


### PR DESCRIPTION
Busquei no site da Improve It por um link atualizado mas não achei nada parecido com documentação de API. 

Achei uma lista de posts antigos no blog, mas não parecia apropriado: http://blog.improveit.com.br/articles/tag/brazilianrails

Se este for o link que deveria ser usado no readme, me avise que eu corrijo.
